### PR TITLE
Bugfix: message sent as encoded garbage (Mandrill)

### DIFF
--- a/src/SlmMail/Service/AbstractMailService.php
+++ b/src/SlmMail/Service/AbstractMailService.php
@@ -75,7 +75,7 @@ abstract class AbstractMailService implements MailServiceInterface
 
         foreach ($body->getParts() as $part) {
             if ($part->type === 'text/plain' && $part->disposition !== Mime::DISPOSITION_ATTACHMENT) {
-                return $part->getContent();
+                return $part->getRawContent();
             }
         }
 
@@ -99,7 +99,7 @@ abstract class AbstractMailService implements MailServiceInterface
 
         foreach ($body->getParts() as $part) {
             if ($part->type === 'text/html' && $part->disposition !== Mime::DISPOSITION_ATTACHMENT) {
-                return $part->getContent();
+                return $part->getRawContent();
             }
         }
 


### PR DESCRIPTION
If a Zend\Mail\Message is sent through the Mandrill service, and it contains HTML/text MIME parts which are encoded using either base64 or Quoted-Printable (which is often a good idea when using traditional SMTP), the message is received in its encoded form. This is because `$part->getContent()` returns an encoded version of the content. 

The solution that worked for me was to switch to `$part->getRawContent()`. I'm not sure it is "best" and that it will not break other services (I can only test with Mandrill), but as I said it makes sense to me. 

I specifically refer to a message that was created like this, for example:

```
$body = new MimeMessage();
$bodyText = new MimePart($text);
$bodyText->charset  = 'utf8';
$bodyText->encoding = Mime::ENCODING_BASE64;
$bodyText->type     = Mime::TYPE_TEXT;
$body->addPart($bodyText);
```

I think this is important because it allows the same messages to be sent either through traditional mail transport or through a SlmMail service.
