### PR TITLE
Bump minimum PHP version to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,6 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7.0
-      env:
-        - DEPS=lowest
-    - php: 7.0
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
     - php: 7.2
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "laminas/laminas-mail": "^2.6",
         "laminas/laminas-http": "^2.5",
         "laminas/laminas-mime": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
     "name": "slm/mail",
-    "description": "Integration of various email service providers in the Zend Framework Laminas\\Mail",
+    "description": "Integration of various email service providers in the Laminas\\Mail",
     "license": "BSD-3-Clause",
     "type": "library",
     "keywords": [
-        "zf2",
-        "expressive",
+        "laminas",
+        "mezzio",
         "email",
         "elastic email",
         "elasticemail",
@@ -35,8 +35,7 @@
         "laminas/laminas-mail": "^2.6",
         "laminas/laminas-http": "^2.5",
         "laminas/laminas-mime": "^2.6",
-        "laminas/laminas-servicemanager": "^2.7 || ^3.1",
-        "laminas/laminas-dependency-plugin": "^1.0"
+        "laminas/laminas-servicemanager": "^2.7 || ^3.1"
     },
     "require-dev": {
         "aws/aws-sdk-php-zf2": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "laminas/laminas-serializer": "^2.6",
         "laminas/laminas-config": "^2.6",
         "doctrine/instantiator": "^1.0.5",
-        "phpunit/phpunit": "^5.5"
+        "phpunit/phpunit": "^8.5"
     },
     "suggest": {
         "aws/aws-sdk-php-zf2": "If you need to use Amazon SES"

--- a/tests/SlmMailTest/ConfigProviderTest.php
+++ b/tests/SlmMailTest/ConfigProviderTest.php
@@ -41,9 +41,9 @@
 namespace SlmMail;
 
 use SlmMail\Module;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ConfigProviderTest extends PHPUnit_Framework_TestCase
+class ConfigProviderTest extends TestCase
 {
     public function testConfigProviderGetConfig()
     {

--- a/tests/SlmMailTest/Http/ClientTest.php
+++ b/tests/SlmMailTest/Http/ClientTest.php
@@ -40,10 +40,10 @@
 
 namespace SlmMailTest\Http;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 
-class ClientTest extends PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     public function testAssertSocketAdapterIsUsedByDefault()
     {

--- a/tests/SlmMailTest/Mail/Transport/ElasticEmailTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/ElasticEmailTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class ElasticEmailTransportTest extends PHPUnit_Framework_TestCase
+class ElasticEmailTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/MailgunTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/MailgunTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class MailgunTransportTest extends PHPUnit_Framework_TestCase
+class MailgunTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/MandrillTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/MandrillTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class MandrillTransportTest extends PHPUnit_Framework_TestCase
+class MandrillTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/PostageTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/PostageTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class PostageTransportTest extends PHPUnit_Framework_TestCase
+class PostageTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/PostmarkTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/PostmarkTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class PostmarkTransportTest extends PHPUnit_Framework_TestCase
+class PostmarkTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/SendGridTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/SendGridTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class SendGridTransportTest extends PHPUnit_Framework_TestCase
+class SendGridTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/SesTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/SesTransportTest.php
@@ -40,11 +40,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class SesTransportTest extends PHPUnit_Framework_TestCase
+class SesTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Mail/Transport/SparkPostTransportTest.php
+++ b/tests/SlmMailTest/Mail/Transport/SparkPostTransportTest.php
@@ -2,11 +2,11 @@
 
 namespace SlmMail\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Mail\Message;
 
-class SparkPostTransportTest extends PHPUnit_Framework_TestCase
+class SparkPostTransportTest extends TestCase
 {
     public function testCreateFromFactory()
     {

--- a/tests/SlmMailTest/Service/ElasticEmailServiceTest.php
+++ b/tests/SlmMailTest/Service/ElasticEmailServiceTest.php
@@ -40,19 +40,19 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SlmMail\Service\ElasticEmailService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class ElasticEmailServiceTest extends PHPUnit_Framework_TestCase
+class ElasticEmailServiceTest extends TestCase
 {
     /**
      * @var ElasticEmailService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new ElasticEmailService('my-username', 'my-secret-key');
     }

--- a/tests/SlmMailTest/Service/MailServiceInterfaceTest.php
+++ b/tests/SlmMailTest/Service/MailServiceInterfaceTest.php
@@ -40,7 +40,7 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SlmMailTest\Asset\SimpleMailService;
 use Laminas\Mail\Message;
@@ -48,14 +48,14 @@ use Laminas\Mime\Message as MimeMessage;
 use Laminas\Mime\Mime;
 use Laminas\Mime\Part as MimePart;
 
-class MailServiceInterfaceTest extends PHPUnit_Framework_testCase
+class MailServiceInterfaceTest extends TestCase
 {
     /**
      * @var SimpleMailService
      */
     protected $simpleMailService;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->simpleMailService = new SimpleMailService();
     }

--- a/tests/SlmMailTest/Service/MailgunServiceTest.php
+++ b/tests/SlmMailTest/Service/MailgunServiceTest.php
@@ -40,20 +40,20 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SlmMail\Service\MailgunService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class MailgunServiceTest extends PHPUnit_Framework_TestCase
+class MailgunServiceTest extends TestCase
 {
     /**
      * @var MailgunService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new MailgunService('my-domain', 'my-secret-key', 'mail-api-endpoint');
     }
@@ -86,8 +86,11 @@ class MailgunServiceTest extends PHPUnit_Framework_TestCase
         $response = new HttpResponse();
         $response->setStatusCode($statusCode);
 
-        $this->setExpectedException($expectedException);
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
 
-        $method->invoke($this->service, $response);
+        $actual = $method->invoke($this->service, $response);
+        $this->assertNull($actual);
     }
 }

--- a/tests/SlmMailTest/Service/MandrillServiceTest.php
+++ b/tests/SlmMailTest/Service/MandrillServiceTest.php
@@ -40,20 +40,20 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SlmMail\Service\MandrillService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class MandrillServiceTest extends PHPUnit_Framework_TestCase
+class MandrillServiceTest extends TestCase
 {
     /**
      * @var MandrillService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new MandrillService('my-secret-key');
     }
@@ -87,8 +87,11 @@ class MandrillServiceTest extends PHPUnit_Framework_TestCase
         $response->setStatusCode($statusCode);
         $response->setContent($content);
 
-        $this->setExpectedException($expectedException);
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
 
-        $method->invoke($this->service, $response);
+        $actual = $method->invoke($this->service, $response);
+        $this->assertNull($actual);
     }
 }

--- a/tests/SlmMailTest/Service/PostageServiceTest.php
+++ b/tests/SlmMailTest/Service/PostageServiceTest.php
@@ -40,20 +40,20 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SlmMail\Service\PostageService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class PostageServiceTest extends PHPUnit_Framework_TestCase
+class PostageServiceTest extends TestCase
 {
     /**
      * @var PostageService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new PostageService('my-secret-key');
     }
@@ -84,8 +84,11 @@ class PostageServiceTest extends PHPUnit_Framework_TestCase
         $response = new HttpResponse();
         $response->setStatusCode($statusCode);
 
-        $this->setExpectedException($expectedException);
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
 
-        $method->invoke($this->service, $response);
+        $actual = $method->invoke($this->service, $response);
+        $this->assertEquals([], $actual);
     }
 }

--- a/tests/SlmMailTest/Service/PostmarkServiceTest.php
+++ b/tests/SlmMailTest/Service/PostmarkServiceTest.php
@@ -40,20 +40,20 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SlmMail\Service\PostmarkService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class PostmarkServiceTest extends PHPUnit_Framework_TestCase
+class PostmarkServiceTest extends TestCase
 {
     /**
      * @var PostmarkService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new PostmarkService('my-secret-key');
     }
@@ -86,8 +86,11 @@ class PostmarkServiceTest extends PHPUnit_Framework_TestCase
         $response = new HttpResponse();
         $response->setStatusCode($statusCode);
 
-        $this->setExpectedException($expectedException);
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
 
-        $method->invoke($this->service, $response);
+        $actual = $method->invoke($this->service, $response);
+        $this->assertNull($actual);
     }
 }

--- a/tests/SlmMailTest/Service/SendGridServiceTest.php
+++ b/tests/SlmMailTest/Service/SendGridServiceTest.php
@@ -40,19 +40,20 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use SlmMail\Service\SendGridService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class SendGridServiceTest extends PHPUnit_Framework_TestCase
+class SendGridServiceTest extends TestCase
 {
     /**
      * @var SendGridService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new SendGridService('my-username', 'my-secret-key');
     }
@@ -79,14 +80,17 @@ class SendGridServiceTest extends PHPUnit_Framework_TestCase
      */
     public function testExceptionsAreThrownOnErrors($statusCode, $expectedException)
     {
-        /*$method = new ReflectionMethod('SlmMail\Service\MailgunService', 'parseResponse');
+        /*$method = new ReflectionMethod(SendGridService::class, 'parseResponse');
         $method->setAccessible(true);
 
         $response = new HttpResponse();
         $response->setStatusCode($statusCode);
 
-        $this->setExpectedException($expectedException);
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
 
-        $method->invoke($this->service, $response);*/
+        $actual = $method->invoke($this->service, $response);
+        $this->assertNull($actual);*/
     }
 }

--- a/tests/SlmMailTest/Service/SparkPostServiceTest.php
+++ b/tests/SlmMailTest/Service/SparkPostServiceTest.php
@@ -2,20 +2,20 @@
 
 namespace SlmMailTest\Service;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SlmMail\Service\SparkPostService;
 use SlmMailTest\Util\ServiceManagerFactory;
 use Laminas\Http\Response as HttpResponse;
 
-class SparkPostServiceTest extends PHPUnit_Framework_TestCase
+class SparkPostServiceTest extends TestCase
 {
     /**
      * @var SparkPostService
      */
     protected $service;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->service = new SparkPostService('my-secret-key');
     }
@@ -47,8 +47,11 @@ class SparkPostServiceTest extends PHPUnit_Framework_TestCase
         $response->setStatusCode($statusCode);
         $response->setContent($content);
 
-        $this->setExpectedException($expectedException);
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
 
-        $method->invoke($this->service, $response);
+        $actual = $method->invoke($this->service, $response);
+        $this->assertNull($actual);
     }
 }


### PR DESCRIPTION
As requested in #123, this PR updates the minimum PHP version to 7.2. 

I've also updated the PHPUnit version to 8.5 and fixed the namespaces in the tests. There were a couple of fails around calls to non-existent `setExpectedException()` that needed fixing.

`SendGridServiceTest::testExceptionsAreThrownOnErrors()` is showing as risky because it was commented out. I had a quick look at fixing it, but couldn't work out what needed doing, so left as is - sorry 🙁 