### PR TITLE
Updated minimum dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,22 +32,23 @@
     ],
     "require": {
         "php": "^7.2",
-        "laminas/laminas-mail": "^2.6",
-        "laminas/laminas-http": "^2.5",
-        "laminas/laminas-mime": "^2.6",
-        "laminas/laminas-servicemanager": "^2.7 || ^3.1"
+        "laminas/laminas-mail": "^2.10",
+        "laminas/laminas-http": "^2.11",
+        "laminas/laminas-mime": "^2.7",
+        "laminas/laminas-servicemanager": "^3.4"
     },
     "require-dev": {
-        "aws/aws-sdk-php-zf2": "~2.0",
+        "aws/aws-sdk-php-zf2": "~4.2",
         "container-interop/container-interop": "^1.1",
-        "laminas/laminas-modulemanager": "^2.7",
-        "laminas/laminas-mvc": "^2.7 || ^3.0",
-        "laminas/laminas-view": "^2.6",
-        "laminas/laminas-log": "^2.6",
-        "laminas/laminas-i18n": "^2.6",
-        "laminas/laminas-serializer": "^2.6",
-        "laminas/laminas-config": "^2.6",
-        "doctrine/instantiator": "^1.0.5",
+        "guzzlehttp/guzzle": "^6.5",
+        "laminas/laminas-modulemanager": "^2.8",
+        "laminas/laminas-mvc": "^3.1",
+        "laminas/laminas-view": "^2.11",
+        "laminas/laminas-log": "^2.12",
+        "laminas/laminas-i18n": "^2.10",
+        "laminas/laminas-serializer": "^2.9",
+        "laminas/laminas-config": "^3.3",
+        "doctrine/instantiator": "^1.3",
         "phpunit/phpunit": "^8.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
     ],
     "require": {
         "php": "^7.2",
-        "laminas/laminas-mail": "^2.10",
-        "laminas/laminas-http": "^2.11",
+        "laminas/laminas-mail": "^2.9",
+        "laminas/laminas-http": "^2.8",
         "laminas/laminas-mime": "^2.7",
-        "laminas/laminas-servicemanager": "^3.4"
+        "laminas/laminas-servicemanager": "^3.3"
     },
     "require-dev": {
         "aws/aws-sdk-php-zf2": "~4.2",

--- a/src/SlmMail/Service/MandrillService.php
+++ b/src/SlmMail/Service/MandrillService.php
@@ -970,22 +970,26 @@ class MandrillService extends AbstractMailService
             return $result;
         }
 
-        switch ($result['name']) {
+        $name = $result['name'] ?? '';
+        $code = $result['code'] ?? '';
+        $message = $result['message'] ?? '';
+        
+        switch ($name) {
             case 'InvalidKey':
                 throw new Exception\InvalidCredentialsException(sprintf(
-                    'Mandrill authentication error (code %s): %s', $result['code'], $result['message']
+                    'Mandrill authentication error (code %s): %s', $code, $message
                 ));
             case 'ValidationError':
                 throw new Exception\ValidationErrorException(sprintf(
-                    'An error occurred on Mandrill (code %s): %s', $result['code'], $result['message']
+                    'An error occurred on Mandrill (code %s): %s', $code, $message
                 ));
             case 'Unknown_Template':
                 throw new Exception\UnknownTemplateException(sprintf(
-                    'An error occurred on Mandrill (code %s): %s', $result['code'], $result['message']
+                    'An error occurred on Mandrill (code %s): %s', $code, $message
                 ));
             default:
                 throw new Exception\RuntimeException(sprintf(
-                    'An error occurred on Mandrill (code %s): %s', $result['code'], $result['message']
+                    'An error occurred on Mandrill (code %s): %s', $code, $message
                 ));
         }
     }

--- a/src/SlmMail/Service/PostageService.php
+++ b/src/SlmMail/Service/PostageService.php
@@ -291,7 +291,8 @@ class PostageService extends AbstractMailService
             return isset($result['data']) ? $result['data'] : array();
         }
 
-        if ($result['response']['status'] !== 'ok') {
+        $status = $result['response']['status'] ?? '';
+        if ($status !== 'ok') {
             $errors = false;
             if (isset($result['data']) && isset($result['data']['errors'])) {
                 $errors = implode(', ', $result['data']['errors']);
@@ -304,9 +305,9 @@ class PostageService extends AbstractMailService
                 ));
             } else {
                 throw new Exception\RuntimeException(sprintf(
-                    'An error occurred on Postage, status code: %s%s', $result['response']['status'],
+                    'An error occurred on Postage, status code: %s%s', $status,
                     ($errors) ? ' (' . $errors . ')' : ''
-                ), (int) $result['response']['status']);
+                ), (int) $status);
             }
         }
 

--- a/src/SlmMail/Service/PostmarkService.php
+++ b/src/SlmMail/Service/PostmarkService.php
@@ -337,13 +337,15 @@ class PostmarkService extends AbstractMailService
             return $result;
         }
 
+        $errorCode = $result['ErrorCode'] ?? '';
+        $message = $result['Message'] ?? '';
         switch ($response->getStatusCode()) {
             case 401:
                 throw new Exception\InvalidCredentialsException('Authentication error: missing or incorrect Postmark API Key header');
             case 422:
                 throw new Exception\ValidationErrorException(sprintf(
-                    'An error occured on Postmark (error code %s), message: %s', $result['ErrorCode'], $result['Message']
-                ), (int) $result['ErrorCode']);
+                    'An error occured on Postmark (error code %s), message: %s', $errorCode, $message
+                ), (int) $errorCode);
             case 500:
                 throw new Exception\RuntimeException('Postmark server error, please try again');
             default:


### PR DESCRIPTION
In addition to bumping the `laminas/*` packages for PHP7.2, I had to add a dev dependency on `guzzlehttp/guzzle: ^6.5` - it looks like the `aws-sdk-php` pulls in an old version that throws warnings with PHP7.2.