### PR TITLE
Allow inline and other disposition in Mailgun

### DIFF
--- a/src/SlmMail/Service/MailgunService.php
+++ b/src/SlmMail/Service/MailgunService.php
@@ -179,7 +179,7 @@ class MailgunService extends AbstractMailService
         foreach ($attachments as $attachment) {
             $client->setFileUpload(
                 $attachment->filename,
-                'attachment',
+                $attachment->disposition,
                 $attachment->getRawContent(),
                 $attachment->type
             );


### PR DESCRIPTION
Now all files are fixed to be attachment. So I can't add inline images for example.