### PR TITLE
Improve exception message when Mandrill itself fails

### DIFF
--- a/src/SlmMail/Service/MandrillService.php
+++ b/src/SlmMail/Service/MandrillService.php
@@ -978,6 +978,14 @@ class MandrillService extends AbstractMailService
     {
         $result = json_decode($response->getBody(), true);
 
+        if (!is_array($result)) {
+            throw new Exception\RuntimeException(sprintf(
+                'An error occured on Mandrill (http code %s), could not interpret result as JSON. Body: %s',
+                $response->getStatusCode(),
+                $response->getBody()
+            ));
+        }
+
         if ($response->isSuccess()) {
             return $result;
         }
@@ -985,7 +993,7 @@ class MandrillService extends AbstractMailService
         $name = $result['name'] ?? '';
         $code = $result['code'] ?? '';
         $message = $result['message'] ?? '';
-        
+
         switch ($name) {
             case 'InvalidKey':
                 throw new Exception\InvalidCredentialsException(sprintf(

--- a/tests/SlmMailTest/Service/MandrillServiceTest.php
+++ b/tests/SlmMailTest/Service/MandrillServiceTest.php
@@ -83,7 +83,7 @@ class MandrillServiceTest extends TestCase
     /**
      * @dataProvider exceptionDataProvider
      */
-    public function testExceptionsAreThrownOnErrors($statusCode, $content, $expectedException)
+    public function testExceptionsAreThrownOnErrors($statusCode, $content, $expectedException, $expectedExceptionMessage)
     {
         $method = new ReflectionMethod('SlmMail\Service\MandrillService', 'parseResponse');
         $method->setAccessible(true);
@@ -94,6 +94,7 @@ class MandrillServiceTest extends TestCase
 
         if ($expectedException !== null) {
             $this->expectException($expectedException);
+            $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
         $actual = $method->invoke($this->service, $response);
@@ -103,10 +104,36 @@ class MandrillServiceTest extends TestCase
     public function exceptionDataProvider()
     {
         return [
-            [401, '{"name":"InvalidKey","message":"Invalid credentials", "code":4}', 'SlmMail\Service\Exception\InvalidCredentialsException'],
-            [400, '{"name":"ValidationError","message":"Validation failed", "code":4}', 'SlmMail\Service\Exception\ValidationErrorException'],
-            [400, '{"name":"Unknown_Template","message":"Unknown template", "code":4}', 'SlmMail\Service\Exception\UnknownTemplateException'],
-            [500, '{"name":"GeneralError","message":"Failed", "code":4}', 'SlmMail\Service\Exception\RuntimeException'],
+            [
+                400,
+                'some jiberish, non-JSON',
+                'SlmMail\Service\Exception\RuntimeException',
+                'An error occured on Mandrill (http code 400), could not interpret result as JSON. Body: some jiberish, non-JSON'
+            ],
+            [
+                401,
+                '{"name":"InvalidKey","message":"Invalid credentials", "code":4}',
+                'SlmMail\Service\Exception\InvalidCredentialsException',
+                'Mandrill authentication error (code 4): Invalid credentials'
+            ],
+            [
+                400,
+                '{"name":"ValidationError","message":"Validation failed", "code":4}',
+                'SlmMail\Service\Exception\ValidationErrorException',
+                'An error occurred on Mandrill (code 4): Validation failed'
+            ],
+            [
+                400,
+                '{"name":"Unknown_Template","message":"Unknown template", "code":4}',
+                'SlmMail\Service\Exception\UnknownTemplateException',
+                'An error occurred on Mandrill (code 4): Unknown template'
+            ],
+            [
+                500,
+                '{"name":"GeneralError","message":"Failed", "code":4}',
+                'SlmMail\Service\Exception\RuntimeException',
+                'An error occurred on Mandrill (code 4): Failed'
+            ],
         ];
     }
 }


### PR DESCRIPTION
The current Mandrill implementation assumes that Mandrill will always return valid JSON, but this isn't the case when the API times out or suffers a fatal internal error. SlmMail will still try to parse the error code and message from the response, which always results in the same non-helpful exception message: `An error occurred on Mandrill (code ):`

This PR changes the error message in these situations to also include the HTTP status code and the full response body. The actual implementation was borrowed from [`Service\SendGrid`](https://github.com/JouwWeb/SlmMail/blob/75c050bf916d570a096586b79114e9c0efd53d6a/src/SlmMail/Service/SendGridService.php#L365-L371).

I think this is a generally helpful addition without any downsides and I'd be grateful if it could be merged. :pray: 