### PR TITLE
Add SparkPost suppression-list support

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -43,7 +43,7 @@ namespace SlmMail;
 
 class ConfigProvider
 {
-    public function __invoke()
+    public function __invoke(): array
     {
         $module = new Module();
         $config = $module->getConfig();


### PR DESCRIPTION
Please note that SparkPost has two separate lists, for transactional and non-transactional emails. This PR enables idempotent addition and idempotent removal of individual entries from either one or both the suppression lists.