### PR TITLE
Enable SparkPost return path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^7.4",
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-mvc": "^3.1",
         "laminas/laminas-view": "^2.11",

--- a/src/Mail/Message/SparkPost.php
+++ b/src/Mail/Message/SparkPost.php
@@ -38,10 +38,18 @@ class SparkPost extends Message
     protected $campaignId = null;
 
     /**
-     * Array of attachments. Each attachment has a name, type and base64-encoded data-string without line breaks.
+     * @var array $attachments Array of attachments. Each attachment has a name, type and base64-encoded data-string without line breaks.
      */
     protected $attachments = [];
 
+    /**
+     * @var string|null $returnPath
+     */
+    protected $returnPath = null;
+
+    /**
+     * @param array $options
+     */
     public function __construct(array $options = [])
     {
         $this->setOptions($options);
@@ -234,5 +242,26 @@ class SparkPost extends Message
             'type' => $type,
             'data' => str_replace(["\r", "\n"], '', $data),
         ];
+    }
+
+    /**
+     * Set the return path for this message. SparkPost will overwrite the local part (blabla@...)
+     * of the address, unless you have an enterprise account.
+     * @param string|null $returnPath Must be valid email address.
+     * @return $this
+     */
+    public function setReturnPath(?string $returnPath): SparkPost
+    {
+        $this->returnPath = $returnPath ?: null;
+        return $this;
+    }
+
+    /**
+     * Get the return path for this message.
+     * @return string|null The configured return path, or `null` if no return path was set
+     */
+    public function getReturnPath(): ?string
+    {
+        return $this->returnPath;
     }
 }

--- a/src/Service/SparkPostService.php
+++ b/src/Service/SparkPostService.php
@@ -98,6 +98,10 @@ class SparkPostService extends AbstractMailService
             $post['campaign_id'] = $message->getCampaignId();
         }
 
+        if($message instanceof SparkPostMessage && $message->getReturnPath()) {
+            $post['return_path'] = $message->getReturnPath();
+        }
+
         $response = $this->prepareHttpClient('/transmissions', $post)
             ->send()
         ;

--- a/tests/SlmMailTest/Service/SparkPostServiceTest.php
+++ b/tests/SlmMailTest/Service/SparkPostServiceTest.php
@@ -371,4 +371,31 @@ gmF+z7H8DfgbHPfXV9OdQ1/X9QIfUdZ1Fxh7m5cdAOkUQ+WNf7zM7v8AoNRRQB//2Q==';
         $sparkPostServiceMock = $this->expectApiResponse(200);
         $sparkPostServiceMock->send($message);
     }
+
+
+    public function testReturnPath()
+    {
+        /** @var SparkPost $message */
+        $message = $this->getMessageObject();
+
+        // default value is null
+        $this->assertNull($message->getReturnPath());
+
+        // accepts null-value as a way to unset the return path
+        $message->setReturnPath('non-null-value@example.com');
+        $message->setReturnPath(null);
+        $this->assertNull($message->getReturnPath());
+
+        // nullify empty string
+        $message->setReturnPath('');
+        $this->assertNull($message->getReturnPath());
+
+        // regular use
+        $message->setReturnPath('recipient@example.com');
+        $this->assertEquals('recipient@example.com', $message->getReturnPath());
+
+        // successful transmission injection
+        $sparkPostServiceMock = $this->expectApiResponse(200);
+        $sparkPostServiceMock->send($message);
+    }
 }


### PR DESCRIPTION
I've added a new field to the SparkPost message type to enable setting the return path on SparkPost transmissions.

Also, I've had to update guzzlehttp/guzzle to version 7.x (from 6.5) to fix a failing test (Error was: "Call to undefined method GuzzleHttp\Utils::chooseHandler()"). This may be due to the recent transition to PHP8 locally. Not sure if that change is desired for SlmMail though.